### PR TITLE
Bionic: Remove setup_dhcp function call

### DIFF
--- a/bionic.sh
+++ b/bionic.sh
@@ -157,7 +157,6 @@ while true; do
 done
 
 set_vars
-setup_dhcp
 setup_network
 setup_data_dir
 run_init_scripts


### PR DESCRIPTION
There is setup_dhcp function in xenial, but in bionic it is not present. We think it was removed intentionally and function call should be removed too.